### PR TITLE
fix: pass `WP_Query` instance to pagination template part in `render_posts` method of `PostLoop` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.3
+
+- fix: pass `WP_Query` instance to pagination template part in `render_posts` method of `PostLoop` class.
+
 ## 1.3.2
 
 - fix: pagination should be outside posts in `PostLoop` class.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "madebyaura/aura-wp",
-	"version": "1.3.2",
+	"version": "1.3.3",
 	"description": "",
 	"license": "GPL-2.0",
 	"support": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae33172724d2678989a1640efbc78ba7",
+    "content-hash": "2f20c09d53b1f67b992e0022831a9741",
     "packages": [],
     "packages-dev": [
         {

--- a/src/PostLoop.php
+++ b/src/PostLoop.php
@@ -128,6 +128,7 @@ class PostLoop {
 		<?php else : ?>
 
 			<?php if ( true === $this->args['nothing_found'] ) : ?>
+				<?php $this->args['pagination_args']['query'] = $this->query; ?>
 				<?php Theme::get_template_part( $this->args['nothing_found_slug'] ); ?>
 			<?php endif; ?>
 


### PR DESCRIPTION
Fixes #28